### PR TITLE
MongoDB

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -1,5 +1,8 @@
 # mongodb
 
+This examples shows how to install MongoDB on Kubernetes using StatefulSets.
+Also, it deploys Mongo Express to manage resources on database.
+
 ```
 k3d cluster create example \
     --servers 1 \
@@ -8,4 +11,8 @@ k3d cluster create example \
 
 kubectl apply \
     --kustomize .
+
+kubectl port-forward \
+    service/express 8080:80 \
+    --namespace mongodb
 ```

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -1,0 +1,8 @@
+# mongodb
+
+```
+k3d cluster create example \
+    --servers 1 \
+    --agents 1 \
+    --no-lb
+```

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -5,4 +5,7 @@ k3d cluster create example \
     --servers 1 \
     --agents 1 \
     --no-lb
+
+kubectl apply \
+    --kustomize .
 ```

--- a/mongodb/deployment.yaml
+++ b/mongodb/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: express
+spec:
+  selector:
+    matchLabels:
+      name: express
+  template:
+    metadata:
+      labels:
+        name: express
+    spec:
+      containers:
+        - name: express
+          image: "mongo-express:0.54"
+          ports:
+            - name: http
+              containerPort: 8081
+          env:
+            - name: ME_CONFIG_MONGODB_ADMINUSERNAME
+              value: root
+            - name: ME_CONFIG_MONGODB_ADMINPASSWORD
+              value: root
+            - name: ME_CONFIG_MONGODB_SERVER
+              value: mongodb
+            - name: ME_CONFIG_BASICAUTH_USERNAME
+              value: admin
+            - name: ME_CONFIG_BASICAUTH_PASSWORD
+              value: admin

--- a/mongodb/kustomization.yaml
+++ b/mongodb/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - service.yaml
   - statefulset.yaml
+  - deployment.yaml

--- a/mongodb/kustomization.yaml
+++ b/mongodb/kustomization.yaml
@@ -3,3 +3,4 @@ namespace: mongodb
 resources:
   - namespace.yaml
   - service.yaml
+  - statefulset.yaml

--- a/mongodb/kustomization.yaml
+++ b/mongodb/kustomization.yaml
@@ -2,3 +2,4 @@ namespace: mongodb
 
 resources:
   - namespace.yaml
+  - service.yaml

--- a/mongodb/kustomization.yaml
+++ b/mongodb/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: mongodb
+
+resources:
+  - namespace.yaml

--- a/mongodb/namespace.yaml
+++ b/mongodb/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mongodb

--- a/mongodb/service.yaml
+++ b/mongodb/service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+spec:
+  ports:
+    - name: mongodb
+      port: 27018
+      targetPort: mongodb

--- a/mongodb/service.yaml
+++ b/mongodb/service.yaml
@@ -1,3 +1,5 @@
+---
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -5,5 +7,21 @@ metadata:
 spec:
   ports:
     - name: mongodb
-      port: 27018
+      port: 27017
       targetPort: mongodb
+  selector:
+    name: mongodb
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: express
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    name: express

--- a/mongodb/statefulset.yaml
+++ b/mongodb/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
           image: "mongo:5.0"
           ports:
             - name: mongodb
-              containerPort: 27018
+              containerPort: 27017
           env:
             - name: MONGO_INITDB_ROOT_USERNAME
               value: root
@@ -36,4 +36,3 @@ spec:
         resources:
           requests:
             storage: 1G
-

--- a/mongodb/statefulset.yaml
+++ b/mongodb/statefulset.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+spec:
+  serviceName: mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mongodb
+  template:
+    metadata:
+      labels:
+        name: mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: "mongo:5.0"
+          ports:
+            - name: mongodb
+              containerPort: 27018
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              value: root
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              value: root
+          volumeMounts:
+            - name: mongodb-data
+              mountPath: /data/db
+  volumeClaimTemplates:
+    - metadata:
+        name: mongodb-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1G
+


### PR DESCRIPTION
This PR adds an example of how to deploy MongoDB and Mongo Express into Kubernetes using `StatefulSet` and `Deployment`.