### PR TITLE
One replica per node

### DIFF
--- a/one-replica-per-node/README.md
+++ b/one-replica-per-node/README.md
@@ -11,6 +11,11 @@ This config will improve reliability if cluster nodes stop constantly, because
 if one node stops, it will guarantee that other replicas are running on other
 nodes.
 
+The last point is this example cluster has 3 agents, there is not autoscaling,
+and our deployment has 3 replicas. If you need to rollout this deployment, it
+will not schedule new pods because there is not available nodes according to
+anti affinity rules.
+
 ```
 k3d cluster create example \
     --servers 1 \
@@ -26,9 +31,11 @@ kubectl apply \
 ```
 
 ```
+$ kubectl rollout restart deployment example --namespace example
 $ kubectl get pods --namespace example --output wide
-NAME                      READY   STATUS    RESTARTS   AGE   IP          NODE                  NOMINATED NODE   READINESS GATES
-example-7cfd9ffb4-b5th2   1/1     Running   0          9s    10.42.1.8   k3d-example-agent-2   <none>           <none>
-example-7cfd9ffb4-ss9k7   1/1     Running   0          9s    10.42.3.8   k3d-example-agent-0   <none>           <none>
-example-7cfd9ffb4-jhcwr   1/1     Running   0          9s    10.42.2.9   k3d-example-agent-1   <none>           <none>
+NAME                       READY   STATUS    RESTARTS   AGE   IP          NODE                  NOMINATED NODE   READINESS GATES
+example-7cfd9ffb4-b5th2    1/1     Running   0          18m   10.42.1.8   k3d-example-agent-2   <none>           <none>
+example-7cfd9ffb4-ss9k7    1/1     Running   0          18m   10.42.3.8   k3d-example-agent-0   <none>           <none>
+example-7cfd9ffb4-jhcwr    1/1     Running   0          18m   10.42.2.9   k3d-example-agent-1   <none>           <none>
+example-647568f54f-2ld8d   0/1     Pending   0          17m   <none>      <none>                <none>           <none>
 ```

--- a/one-replica-per-node/README.md
+++ b/one-replica-per-node/README.md
@@ -9,4 +9,15 @@ k3d cluster create example \
 kubectl taint nodes \
     --selector node-role.kubernetes.io/master=true \
     node-role.kubernetes.io/master=:NoSchedule
+
+kubectl apply \
+    --kustomize .
+```
+
+```
+$ kubectl get pods --namespace example --output wide
+NAME                      READY   STATUS    RESTARTS   AGE   IP          NODE                  NOMINATED NODE   READINESS GATES
+example-7cfd9ffb4-b5th2   1/1     Running   0          9s    10.42.1.8   k3d-example-agent-2   <none>           <none>
+example-7cfd9ffb4-ss9k7   1/1     Running   0          9s    10.42.3.8   k3d-example-agent-0   <none>           <none>
+example-7cfd9ffb4-jhcwr   1/1     Running   0          9s    10.42.2.9   k3d-example-agent-1   <none>           <none>
 ```

--- a/one-replica-per-node/README.md
+++ b/one-replica-per-node/README.md
@@ -7,6 +7,10 @@ Basically, it defines a rule that avoids pod schedule if some pod is running
 according to match expression by key. In this example, it checks if pods of the
 same deployment are running by node hostname, avoiding schedule.
 
+This config will improve reliability if cluster nodes stop constantly, because
+if one node stops, it will guarantee that other replicas are running on other
+nodes.
+
 ```
 k3d cluster create example \
     --servers 1 \

--- a/one-replica-per-node/README.md
+++ b/one-replica-per-node/README.md
@@ -3,7 +3,7 @@
 This example shows how to use anti affinity to run one deployment replica per
 cluster node.
 
-Basically, it defines a rule that avoids pod schedule if some pod is running
+Basically, it defines a rule that avoids pod scheduling if some pod is running
 according to match expression by key. In this example, it checks if pods of the
 same deployment are running by node hostname, avoiding schedule.
 
@@ -11,7 +11,7 @@ This config will improve reliability if cluster nodes stop constantly, because
 if one node stops, it will guarantee that other replicas are running on other
 nodes.
 
-The last point is this example cluster has 3 agents, there is not autoscaling,
+One issue to avoid: this cluster example has 3 agents, there is not autoscaling,
 and our deployment has 3 replicas. If you need to rollout this deployment, it
 will not schedule new pods because there is not available nodes according to
 anti affinity rules.

--- a/one-replica-per-node/README.md
+++ b/one-replica-per-node/README.md
@@ -11,11 +11,6 @@ This config will improve reliability if cluster nodes stop constantly, because
 if one node stops, it will guarantee that other replicas are running on other
 nodes.
 
-One issue to avoid: this cluster example has 3 agents, there is not autoscaling,
-and our deployment has 3 replicas. If you need to rollout this deployment, it
-will not schedule new pods because there is not available nodes according to
-anti affinity rules.
-
 ```
 k3d cluster create example \
     --servers 1 \
@@ -29,6 +24,19 @@ kubectl taint nodes \
 kubectl apply \
     --kustomize .
 ```
+
+```
+$ kubectl get pods --namespace example --output wide
+NAME                       READY   STATUS    RESTARTS   AGE   IP          NODE                  NOMINATED NODE   READINESS GATES
+example-7cfd9ffb4-b5th2    1/1     Running   0          18m   10.42.1.8   k3d-example-agent-2   <none>           <none>
+example-7cfd9ffb4-ss9k7    1/1     Running   0          18m   10.42.3.8   k3d-example-agent-0   <none>           <none>
+example-7cfd9ffb4-jhcwr    1/1     Running   0          18m   10.42.2.9   k3d-example-agent-1   <none>           <none>
+```
+
+One issue to avoid: this cluster example has 3 agents, there is not autoscaling,
+and our deployment has 3 replicas. If you need to rollout this deployment, it
+will not schedule new pods because there is not available nodes according to
+anti affinity rules.
 
 ```
 $ kubectl rollout restart deployment example --namespace example

--- a/one-replica-per-node/README.md
+++ b/one-replica-per-node/README.md
@@ -1,1 +1,12 @@
 # one-replica-per-node
+
+```
+k3d cluster create example \
+    --servers 1 \
+    --agents 3 \
+    --no-lb
+
+kubectl taint nodes \
+    --selector node-role.kubernetes.io/master=true \
+    node-role.kubernetes.io/master=:NoSchedule
+```

--- a/one-replica-per-node/README.md
+++ b/one-replica-per-node/README.md
@@ -1,5 +1,12 @@
 # one-replica-per-node
 
+This example shows how to use anti affinity to run one deployment replica per
+cluster node.
+
+Basically, it defines a rule that avoids pod schedule if some pod is running
+according to match expression by key. In this example, it checks if pods of the
+same deployment are running by node hostname, avoiding schedule.
+
 ```
 k3d cluster create example \
     --servers 1 \

--- a/one-replica-per-node/README.md
+++ b/one-replica-per-node/README.md
@@ -1,0 +1,1 @@
+# one-replica-per-node

--- a/one-replica-per-node/deployment.yaml
+++ b/one-replica-per-node/deployment.yaml
@@ -15,3 +15,13 @@ spec:
       containers:
         - name: nginx
           image: "nginx:1.21"
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - example

--- a/one-replica-per-node/deployment.yaml
+++ b/one-replica-per-node/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: example
+  template:
+    metadata:
+      labels:
+        app: example
+    spec:
+      containers:
+        - name: nginx
+          image: "nginx:1.21"

--- a/one-replica-per-node/kustomization.yaml
+++ b/one-replica-per-node/kustomization.yaml
@@ -1,0 +1,5 @@
+namespace: example
+
+resources:
+  - namespace.yaml
+  - deployment.yaml

--- a/one-replica-per-node/namespace.yaml
+++ b/one-replica-per-node/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example


### PR DESCRIPTION
This PR adds an example of running one deployment replica per cluster node using pod anti affinity.