### PR TITLE
Added: multiply current replicas option on cronjob-scale

### DIFF
--- a/cronjob-scale/configmap.yaml
+++ b/cronjob-scale/configmap.yaml
@@ -27,10 +27,18 @@ data:
     chmod +x /usr/bin/kubectl
 
     DEPLOYMENT_PATCH=`mktemp`
+    if [ -z "$2"]
+    then
+      echo "$1" \
+        | jq '{"spec": {"replicas": .}}' \
+        | jq --compact-output > "$DEPLOYMENT_PATCH"
+    else
+      REPLICAS_NOW=`kubectl get deployment app-example -o=jsonpath='{.spec.replicas}'`
+      echo $(expr $1 '*' $REPLICAS_NOW) \
+        | jq '{"spec": {"replicas": .}}' \
+        | jq --compact-output > "$DEPLOYMENT_PATCH"
+    fi
 
-    echo "$1" \
-      | jq '{"spec": {"replicas": .}}' \
-      | jq --compact-output > "$DEPLOYMENT_PATCH"
 
     kubectl patch deployment app-example \
       --type merge \

--- a/cronjob-scale/cronjob.yaml
+++ b/cronjob-scale/cronjob.yaml
@@ -28,6 +28,7 @@ spec:
               command:
                 - scale.sh
                 - "10"
+                - "true"
               volumeMounts:
                 - name: bin
                   mountPath: /usr/local/bin
@@ -70,7 +71,7 @@ spec:
               image: alpine:3.16
               command:
                 - scale.sh
-                - "1"
+                - "2"
               volumeMounts:
                 - name: bin
                   mountPath: /usr/local/bin

--- a/cronjob-scale/deployment.yaml
+++ b/cronjob-scale/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: app-example
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: app-example


### PR DESCRIPTION
What if we could pass a second argument to the script and it gets the current minimum number of replicas and multiply it by the desired value?

```cronjob-scale/cronjob.yaml
              command:
                - scale.sh
                - "10"
                - "true" // when this argument is passed it will multiply instead of using the fixed value above.
```

**important** this PR does not break compatibility, it allows both uses of fixed value or multiplying the minimum replicas by the desired value.